### PR TITLE
Add typing, tests, coverage, and docs infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+      - name: Run mypy
+        run: mypy src/bare/main.py src/bare/utils.py
+      - name: Run tests
+        run: pytest --cov=src/bare --cov-report=xml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Deploy docs
+        run: mkdocs gh-deploy --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,8 @@ repos:
   hooks:
     - id: python-check-blanket-noqa
     - id: python-no-log-warn
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.11.1
+  hooks:
+    - id: mypy
+      files: ^src/bare/(main|utils)\.py$

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project adheres to the [Contributor Covenant](https://www.contributor-covenant.org/) Code of Conduct.
+
+Please report unacceptable behavior to [bare@felipecastrotc.com](mailto:bare@felipecastrotc.com).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing to BARE
+
+Thank you for considering contributing!
+
+## Development Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -e .[dev]
+   ```
+2. Run code quality checks:
+   ```bash
+   pre-commit run --all-files
+   ```
+3. Run tests:
+   ```bash
+   pytest
+   ```
+
+## Workflow
+
+- Fork the repository and create your branch from `main`.
+- Ensure pre-commit hooks and tests pass before submitting a pull request.
+- Describe your changes and include relevant tests.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 - **Automatic Mounting**: Automatically mount and unmount volumes or rclone remotes by specifying the volume label or rclone name.
 - **Cross-Platform Support**: Supports Linux, Android and macOS.
 
+## Documentation
+
+See the full documentation at [felipecastrotc.github.io/bare](https://felipecastrotc.github.io/bare/).
+
 ## Installation
 
 1. Clone the repository:
@@ -134,25 +138,9 @@ To create a custom session, create a `session.yml` file in your home directory u
 
 ## Contributing
 
-Contributions are welcome! Please open an issue or submit a pull request on GitHub if you have suggestions, bug reports, or enhancements.
+Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for setup and development guidelines.
 
-### Development
-
-To maintain code quality, BARE uses `black` for code formatting. Please ensure that your code is formatted with `black` before submitting a pull request.
-
-To format your code with `black`, install it using pip:
-
-```bash
-pip install black
-```
-
-Then, format your code by running:
-
-```bash
-black .
-```
-
-This will automatically format all Python files in the current directory to conform to the `black` code style.
+Please note that this project is released with a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to abide by its terms.
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+# BARE Documentation
+
+Welcome to the BARE documentation site.
+
+- [Repository on GitHub](https://github.com/felipecastrotc/bare)
+- Use the `bare` command line tool for backups.
+
+Additional pages can be added to expand usage and API details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,4 @@
+site_name: BARE
+nav:
+  - Home: index.md
+docs_dir: docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,14 @@ dynamic = ["version"]
 dependencies = ["pyyaml>=6.0.2,<7"]
 
 [project.optional-dependencies]
-dev = ["ruff>=0.12.10,<0.13", "pre-commit>=4.3.0,<5"]
+dev = [
+  "ruff>=0.12.10,<0.13",
+  "pre-commit>=4.3.0,<5",
+  "mypy>=1.11,<2",
+  "pytest>=8.2,<9",
+  "pytest-cov>=5,<6",
+  "mkdocs>=1.6,<2",
+]
 
 [project.urls]
 Homepage = "https://github.com/felipecastrotc/bare"
@@ -83,6 +90,14 @@ indent-style = "space"
 line-ending = "lf"
 
 
+[tool.coverage.run]
+branch = true
+source = ["src/bare"]
+
+[tool.coverage.report]
+show_missing = true
+
+
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["tests"]
@@ -91,6 +106,8 @@ testpaths = ["tests"]
 python_version = "3.12"
 strict = true
 warn_unused_ignores = true
+ignore_missing_imports = true
+follow_imports = "skip"
 
 [tool.pixi.workspace]
 channels = ["conda-forge"]

--- a/src/bare/main.py
+++ b/src/bare/main.py
@@ -1,12 +1,16 @@
 #!/usr/bin/python
 
+from __future__ import annotations
+
 import argparse
 import collections.abc
 import copy
 import logging
 import os
+from collections.abc import Mapping
+from typing import Any
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 from . import DestinationHandler, MountManager, Restic, Rsync
 from .utils import InfoOnlyFormatter, get_hostname
@@ -19,13 +23,13 @@ logging.basicConfig(level=logging.INFO, handlers=[handler])
 logger = logging.getLogger(__name__)
 
 
-def update_nested(d, u):
+def update_nested(d: dict[str, Any] | None, u: Mapping[str, Any]) -> dict[str, Any]:
     """
     Recursively update a nested dictionary `d` with values from dictionary `u`.
     This is useful for merging configurations.
     """
     if d is None:
-        return u
+        return dict(u)
     for k, v in u.items():
         if isinstance(v, collections.abc.Mapping):
             d[k] = update_nested(d.get(k, {}), v)
@@ -34,7 +38,7 @@ def update_nested(d, u):
     return d
 
 
-default_var = {
+default_var: dict[str, Any] = {
     "hostname": None,
     "source": [None],
     "mask": None,
@@ -57,7 +61,12 @@ default_var = {
 }
 
 
-def get_restic_instance(config, destination_path, name, destination_type=None):
+def get_restic_instance(
+    config: dict[str, Any],
+    destination_path: str,
+    name: str,
+    destination_type: str | None = None,
+) -> Restic:
     if destination_type == "restic_rest_server":
         restic_folder = ""
     else:
@@ -75,7 +84,9 @@ def get_restic_instance(config, destination_path, name, destination_type=None):
     return restic_instance
 
 
-def get_rsync_instance(config, destination_path, name):
+def get_rsync_instance(
+    config: dict[str, Any], destination_path: str, name: str
+) -> Rsync:
     rsync_instance = Rsync(
         destination_path,
         rsync_folder=config["rsync"]["rsync_folder"],
@@ -86,7 +97,7 @@ def get_rsync_instance(config, destination_path, name):
     return rsync_instance
 
 
-def post_backup_restic(restic_instance, config):
+def post_backup_restic(restic_instance: Restic, config: dict[str, Any]) -> None:
     if not config["restic"]["skip-maintain"]:
         forget_config = config.get("restic", {}).get("forget")
         if isinstance(forget_config, dict):
@@ -101,7 +112,7 @@ def post_backup_restic(restic_instance, config):
             logger.info("Restic: Finished checking repository!")
 
 
-def backup(var):
+def backup(var: dict[str, dict[str, Any]]) -> None:
     """
     Perform backup operations using the provided configuration. It handles both
     Restic and Rsync backups based on the configuration.
@@ -143,7 +154,7 @@ def backup(var):
                 logger.info("Skipping to the next drive.")
 
 
-def restic(var, unknown):
+def restic(var: dict[str, dict[str, Any]], unknown: list[str]) -> None:
     """
     Execute a Restic command for each configuration entry.
     """
@@ -161,7 +172,7 @@ def restic(var, unknown):
                 logger.info("Skipping to the next drive.")
 
 
-def maintain(var):
+def maintain(var: dict[str, dict[str, Any]]) -> None:
     """
     Perform maintenance tasks based on provided configuration.
 
@@ -197,7 +208,7 @@ def maintain(var):
                 logger.info("Skipping to the next drive.")
 
 
-def umount(var):
+def umount(var: dict[str, dict[str, Any]]) -> None:
     """
     Unmount and clean the temporary folders created during the backup.
     """
@@ -209,14 +220,16 @@ def umount(var):
         logger.info(f"Error during unmount: {e}")
 
 
-def list_func(var, unknown):
+def list_func(var: dict[str, dict[str, Any]], unknown: list[str]) -> None:
     """
     List all available sessions and configurations.
     """
     logger.info(yaml.dump(list(var.keys())))
 
 
-def router(cmd, var, unknown, target):
+def router(
+    cmd: str, var: dict[str, dict[str, Any]], unknown: list[str], target: str | None
+) -> None:
     """
     Main function to route commands to the appropriate function.
     """
@@ -236,7 +249,7 @@ def router(cmd, var, unknown, target):
             maintain(var)
 
 
-def main():
+def main() -> None:
     # Initialize parser
     #
     parser = argparse.ArgumentParser(

--- a/src/bare/utils.py
+++ b/src/bare/utils.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import logging
 import os
 import platform
 import re
 import subprocess
 import threading
+from collections.abc import Sequence
+from typing import IO, Any
 
 logger = logging.getLogger(__name__)
 
@@ -11,19 +15,19 @@ logger = logging.getLogger(__name__)
 class InfoOnlyFormatter(logging.Formatter):
     """Formatter that uses a simple format for INFO, detailed format otherwise."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.info_fmt = logging.Formatter("%(message)s")
         self.default_fmt = logging.Formatter(
             "[%(asctime)s] %(levelname)s in %(name)s: %(message)s"
         )
 
-    def format(self, record):
+    def format(self, record: logging.LogRecord) -> str:
         if record.levelno == logging.INFO:
             return self.info_fmt.format(record)
         return self.default_fmt.format(record)
 
 
-def setup_environment(env_vars=None):
+def setup_environment(env_vars: dict[str, str] | None = None) -> dict[str, str]:
     """
     Prepare and return the environment settings for the subprocess.
 
@@ -39,7 +43,7 @@ def setup_environment(env_vars=None):
     return environment
 
 
-def modify_command_for_os(command, mask=None):
+def modify_command_for_os(command: str, mask: Sequence[str] | None = None) -> str:
     """
     Modify the command based on the operating system, such as using proot on Linux.
 
@@ -57,7 +61,7 @@ def modify_command_for_os(command, mask=None):
     return command
 
 
-def stream_reader(pipe, output_list):
+def stream_reader(pipe: IO[str], output_list: list[str]) -> None:
     """Read from the pipe line by line and store the output in the provided list."""
     for line in iter(pipe.readline, ""):
         print(line, end="", flush=True)  # noqa: T201
@@ -65,7 +69,12 @@ def stream_reader(pipe, output_list):
     pipe.close()
 
 
-def execute_command(command, env_vars=None, mask=None, ignore_error=False):
+def execute_command(
+    command: str,
+    env_vars: dict[str, str] | None = None,
+    mask: Sequence[str] | None = None,
+    ignore_error: bool = False,
+) -> str:
     """
     Execute a terminal command with optional environment variables and path masking,
     and return the output.
@@ -85,8 +94,8 @@ def execute_command(command, env_vars=None, mask=None, ignore_error=False):
     command = modify_command_for_os(command, mask)
 
     # Initialize lists to capture standard output and error streams
-    stdout_output = []
-    stderr_output = []
+    stdout_output: list[str] = []
+    stderr_output: list[str] = []
 
     # Use subprocess to execute the command, capturing stdout and stderr
     with subprocess.Popen(
@@ -122,7 +131,11 @@ def execute_command(command, env_vars=None, mask=None, ignore_error=False):
     return "".join(stdout_output)
 
 
-def execute_command_test(command, env_vars=None, mask=None):
+def execute_command_test(
+    command: str,
+    env_vars: dict[str, str] | None = None,
+    mask: Sequence[str] | None = None,
+) -> str:
     """
     Execute a terminal command with optional environment variables and path masking,
     and return the output.
@@ -145,7 +158,7 @@ def execute_command_test(command, env_vars=None, mask=None):
     return command
 
 
-def build_command(command, *args):
+def build_command(command: str, *args: Any) -> str:
     """
     Build a shell command by concatenating a base command with additional arguments,
     ensuring proper spacing between each component.
@@ -168,7 +181,7 @@ def build_command(command, *args):
     return full_command
 
 
-def get_hostname():
+def get_hostname() -> str:
     """Retrieve the current machine's hostname.
 
     Returns:
@@ -182,8 +195,14 @@ def get_hostname():
     return hostname
 
 
-def dict2args(args, double="--", single="-", join_double=" ", join_single=" "):
-    def gen_arg(arg, val):
+def dict2args(
+    args: dict[str, Any],
+    double: str = "--",
+    single: str = "-",
+    join_double: str = " ",
+    join_single: str = " ",
+) -> str:
+    def gen_arg(arg: str, val: Any) -> str:
         # Determine the prefix for the argument name.
         arg_name = double + arg if len(arg) > 1 else single + arg
 
@@ -193,7 +212,7 @@ def dict2args(args, double="--", single="-", join_double=" ", join_single=" "):
         # Return the formatted argument string by combining the argument name, join character, and value.
         return arg_name + join + str(val)
 
-    out = []
+    out: list[str] = []
     for k, v in args.items():
         if isinstance(v, list):
             # If the value is a list, generate an argument string for each item in the list.
@@ -207,7 +226,7 @@ def dict2args(args, double="--", single="-", join_double=" ", join_single=" "):
     return " ".join(out)
 
 
-def parse_mount():
+def parse_mount() -> list[dict[str, str]]:
     """
     Parses the output of the 'mount' command to extract details about each mount.
 
@@ -224,7 +243,7 @@ def parse_mount():
 
     output = execute_command("mount")
 
-    mounts = []
+    mounts: list[dict[str, str]] = []
     for line in output.splitlines():
         if platform.system() == "Linux":
             # For Linux, mount output is typically like:

--- a/tests/test_destination_handler.py
+++ b/tests/test_destination_handler.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from bare.destination_handler import DestinationHandler
+
+
+def test_detect_destination_type_restic():
+    dh = DestinationHandler("rest:https://example.com")
+    assert dh.destination_type == "restic_rest_server"
+
+
+def test_detect_destination_type_volume():
+    dh = DestinationHandler("myvolume")
+    assert dh.destination_type == "volume"
+
+
+def test_check_abs_path(tmp_path: Path):
+    path = tmp_path / "data"
+    path.mkdir()
+    dh = DestinationHandler(str(path))
+    assert dh.destination_type == "abs_path"
+    assert dh._check_abs_path() == str(path)
+    with pytest.raises(FileExistsError):
+        DestinationHandler(str(path / "missing"))._check_abs_path()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+import platform
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from bare.utils import build_command, dict2args, modify_command_for_os
+
+
+def test_build_command():
+    assert build_command("echo", "hi", 1) == "echo hi 1"
+
+
+def test_dict2args():
+    args = {"exclude": "/tmp", "I": ["a", "b"]}
+    result = dict2args(args)
+    assert "--exclude /tmp" in result
+    assert "-I a" in result
+    assert "-I b" in result
+
+
+def test_modify_command_for_os_linux_with_mask(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    cmd = modify_command_for_os("ls", ["src", "dst"])
+    assert cmd == "proot -b src:dst ls"


### PR DESCRIPTION
## Summary
- add mypy, coverage, and mkdocs tooling with CI integration
- introduce basic type hints in core modules
- add unit tests, documentation skeleton, and contributor guides

## Testing
- `pre-commit run --files .pre-commit-config.yaml .github/workflows/ci.yml .github/workflows/docs.yml CONTRIBUTING.md CODE_OF_CONDUCT.md README.md docs/index.md mkdocs.yml pyproject.toml src/bare/main.py src/bare/utils.py tests/test_destination_handler.py tests/test_utils.py`
- `mypy src/bare/main.py src/bare/utils.py`
- `pytest --cov=src/bare --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_68a9db396a208324a1bd0e80621a8366