### PR TITLE
Annotate typing across project

### DIFF
--- a/src/bare/__init__.py
+++ b/src/bare/__init__.py
@@ -5,6 +5,8 @@ the backup system, including handlers for backup tools, mounting, and
 destination management.
 """
 
+from __future__ import annotations
+
 # Main Backup Classes
 from .bare.backup import Backup
 from .bare.gocryptfs import Gocryptfs

--- a/src/bare/bare/__init__.py
+++ b/src/bare/bare/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/bare/bare/backup.py
+++ b/src/bare/bare/backup.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import logging
 import os
+from typing import Any
 
 from ..destination_handler import DestinationHandler
 from .base import Base
@@ -25,13 +28,13 @@ class Backup(Base):
 
     def __init__(
         self,
-        source,
-        destination=None,
-        vol_label=None,
-        restic_password=None,
-        hostname=None,
-        name=None,
-    ):
+        source: str,
+        destination: str | None = None,
+        vol_label: str | None = None,
+        restic_password: str | None = None,
+        hostname: str | None = None,
+        name: str | None = None,
+    ) -> None:
         """
         Initializes the backup with necessary parameters.
 
@@ -57,13 +60,13 @@ class Backup(Base):
 
     def perform_backup(
         self,
-        use_restic=False,
-        use_rsync=False,
-        restic_args=None,
-        rsync_args=None,
-        mask=None,
-        dry_run=False,
-    ):
+        use_restic: bool = False,
+        use_rsync: bool = False,
+        restic_args: dict[str, Any] | None = None,
+        rsync_args: dict[str, Any] | None = None,
+        mask: str | None = None,
+        dry_run: bool = False,
+    ) -> None:
         """
         Performs the backup operation using specified methods: Restic or Rsync.
 
@@ -84,7 +87,13 @@ class Backup(Base):
             if use_rsync:
                 self._perform_rsync_backup(base_dest_path, rsync_args, mask, dry_run)
 
-    def _perform_restic_backup(self, base_dest_path, restic_args, mask, dry_run):
+    def _perform_restic_backup(
+        self,
+        base_dest_path: str,
+        restic_args: dict[str, Any],
+        mask: str | None,
+        dry_run: bool,
+    ) -> None:
         """Helper method to encapsulate Restic backup logic."""
         restic_runner = Restic(
             os.path.join(base_dest_path, self.destination),
@@ -96,7 +105,13 @@ class Backup(Base):
         logger.info("Performing Restic backup...")
         restic_runner.backup(self.source, restic_args, mask, dry_run)
 
-    def _perform_rsync_backup(self, base_dest_path, rsync_args, mask, dry_run):
+    def _perform_rsync_backup(
+        self,
+        base_dest_path: str,
+        rsync_args: dict[str, Any],
+        mask: str | None,
+        dry_run: bool,
+    ) -> None:
         """Helper method to encapsulate Rsync backup logic."""
         rsync_runner = Rsync(
             os.path.join(base_dest_path, self.destination),

--- a/src/bare/bare/base.py
+++ b/src/bare/bare/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from ..utils import get_hostname, setup_environment
@@ -18,13 +20,18 @@ class Base:
         mount_drive (MountDrive): Instance for managing mount operations.
     """
 
-    def __init__(self, hostname=None, name=None, check_hostname=True):
+    def __init__(
+        self,
+        hostname: str | None = None,
+        name: str | None = None,
+        check_hostname: bool = True,
+    ) -> None:
         self.env = setup_environment()
         self.name = name or "default_session"
 
         self.hostname = self.confirm_hostname(hostname, check_hostname)
 
-    def confirm_hostname(self, hostname, check=True):
+    def confirm_hostname(self, hostname: str | None, check: bool = True) -> str | None:
         """
         Confirms if the provided hostname matches the current machine's hostname.
         Prompts the user for confirmation if different, allowing to exit or continue.
@@ -33,7 +40,7 @@ class Base:
             hostname (str): The hostname to confirm.
 
         Returns:
-            str: The confirmed hostname or the current machine's hostname if none provided.
+            str | None: The confirmed hostname or the current machine's hostname if none provided.
         """
         if check:
             current_hostname = get_hostname()

--- a/src/bare/bare/gocryptfs.py
+++ b/src/bare/bare/gocryptfs.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
 from ..utils import dict2args, execute_command
 from .base import Base
 
@@ -5,10 +10,10 @@ from .base import Base
 class Gocryptfs(Base):
     def __init__(
         self,
-        path,
-        gocryptfs_password,
-        gocryptfs_folder="",
-    ):
+        path: str,
+        gocryptfs_password: str,
+        gocryptfs_folder: str = "",
+    ) -> None:
         super().__init__(None, None, False)
         # Restic password -> TODO: better way to store the password
         self.env["GOCRYPTFS_PASSWORD"] = gocryptfs_password
@@ -18,24 +23,34 @@ class Gocryptfs(Base):
         # Setup the base directory used to access the repository
         self.cmd = 'gocryptfs -extpass "echo $GOCRYPTFS_PASSWORD" {} {} {}'
 
-    def run(self, cmd="", args=None, mask=None):
+    def run(
+        self,
+        cmd: str = "",
+        args: dict[str, Any] | None = None,
+        mask: str | None = None,
+    ) -> str:
         if args is None:
             args = {}
         cmd = self.cmd.format(dict2args(args, double="-"), self.path, cmd)
         # return execute_command_test(cmd, self.env, mask)
         return execute_command(cmd, self.env, mask)
 
-    def init(self):
+    def init(self) -> None:
         self.run({"init": ""})
 
-    def mount(self, destination, args=None, mask=None):
+    def mount(
+        self,
+        destination: str,
+        args: dict[str, Any] | None = None,
+        mask: str | None = None,
+    ) -> None:
         if args is None:
             args = {}
         self.run(destination, args, mask)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Callable[..., str]:
         # This method is called when an undefined attribute/method is accessed
-        def method(**kwargs):
+        def method(**kwargs: Any) -> str:
             # Redirect the call to the 'run' method with the method name as the command
             return self.run(name, args=kwargs)
 

--- a/src/bare/bare/restic.py
+++ b/src/bare/bare/restic.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 import logging
 import os
 import platform
+from collections.abc import Callable
 from shutil import which
+from typing import Any
 
 from ..utils import dict2args, execute_command
 from .base import Base
@@ -12,15 +16,15 @@ logger = logging.getLogger(__name__)
 class Restic(Base):
     def __init__(
         self,
-        path,
-        password,
-        restic_folder="restic",
-        hostname=None,
-        name=None,
-        check_hostname=True,
-        runner="restic",
-        bin_path=None,
-    ):
+        path: str,
+        password: str,
+        restic_folder: str = "restic",
+        hostname: str | None = None,
+        name: str | None = None,
+        check_hostname: bool = True,
+        runner: str = "restic",
+        bin_path: str | None = None,
+    ) -> None:
         super().__init__(hostname, name, check_hostname)
         # Restic password -> TODO: better way to store the password
         self.env["RESTIC_PASSWORD"] = password
@@ -48,7 +52,14 @@ class Restic(Base):
         else:
             self.repo = f"-r {path}"
 
-    def run(self, cmd, args=None, mask=None, dry_run=False, custom_runner=None):
+    def run(
+        self,
+        cmd: str,
+        args: dict[str, Any] | None = None,
+        mask: str | None = None,
+        dry_run: bool = False,
+        custom_runner: str | None = None,
+    ) -> str:
         if args is None:
             args = {}
         logger.info(f"Context: {self.name}")
@@ -62,10 +73,16 @@ class Restic(Base):
         logger.info(cmd)
         return execute_command(cmd, self.env, mask, ignore_error=True)
 
-    def init(self):
+    def init(self) -> None:
         self.run("init")
 
-    def backup(self, source, args=None, mask=None, dry_run=False):
+    def backup(
+        self,
+        source: str,
+        args: dict[str, Any] | None = None,
+        mask: str | None = None,
+        dry_run: bool = False,
+    ) -> None:
         if args is None:
             args = {}
         if self.hostname is not None:
@@ -89,7 +106,12 @@ class Restic(Base):
                 # Uses proot
                 self.run(base_cmd, args, mask, dry_run)
 
-    def forget(self, options, hostname_filter=True, dry_run=False):
+    def forget(
+        self,
+        options: dict[str, Any],
+        hostname_filter: bool = True,
+        dry_run: bool = False,
+    ) -> None:
         # Base command for forgetting and pruning backups
         base_cmd = "forget --prune "
         # Append the host filter to the command if the hostname is set
@@ -98,12 +120,18 @@ class Restic(Base):
 
         self.run(base_cmd, args=options, dry_run=dry_run)
 
-    def check(self, options, dry_run=False):
+    def check(self, options: dict[str, Any], dry_run: bool = False) -> None:
         # Base command for forgetting and pruning backups
         base_cmd = "check "
         self.run(base_cmd, args=options, dry_run=dry_run)
 
-    def mount(self, destination, args=None, mask=None, dry_run=False):
+    def mount(
+        self,
+        destination: str,
+        args: dict[str, Any] | None = None,
+        mask: str | None = None,
+        dry_run: bool = False,
+    ) -> None:
         # Currently rustic does not support the mount option.
         if args is None:
             args = {}
@@ -111,9 +139,9 @@ class Restic(Base):
             f"mount {destination}", args, mask, dry_run, custom_runner=self.restic_cmd
         )
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Callable[..., str]:
         # This method is called when an undefined attribute/method is accessed
-        def method(**kwargs):
+        def method(**kwargs: Any) -> str:
             # Redirect the call to the 'run' method with the method name as the command
             return self.run(name, args=kwargs)
 

--- a/src/bare/bare/rsync.py
+++ b/src/bare/bare/rsync.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import logging
 import os
+from typing import Any
 
 from ..utils import dict2args, execute_command_test
 from .base import Base
@@ -10,13 +13,13 @@ logger = logging.getLogger(__name__)
 class Rsync(Base):
     def __init__(
         self,
-        path,
-        rsync_folder="rsync",
-        file_options="axHAX",
-        hostname=None,
-        name=None,
-        check_hostname=False,
-    ):
+        path: str,
+        rsync_folder: str = "rsync",
+        file_options: str = "axHAX",
+        hostname: str | None = None,
+        name: str | None = None,
+        check_hostname: bool = False,
+    ) -> None:
         super().__init__(hostname, name, check_hostname)
         # Location of the folder to receive the backup
         self.dest = os.path.join(path, hostname, rsync_folder)
@@ -25,7 +28,13 @@ class Rsync(Base):
         self.base_cmd = f"rsync -{file_options} --info=progress2 --numeric-ids"
         self.base_cmd = self.base_cmd + " {} {} " + self.dest
 
-    def run(self, source_path, args=None, mask=None, dry_run=False):
+    def run(
+        self,
+        source_path: str,
+        args: dict[str, Any] | None = None,
+        mask: str | None = None,
+        dry_run: bool = False,
+    ) -> str:
         if args is None:
             args = {}
         logger.info(f"Context: {self.name}")
@@ -36,13 +45,13 @@ class Rsync(Base):
 
     def backup(
         self,
-        source,
-        args=None,
-        delete=True,
-        ignore_error=True,
-        mask=None,
-        dry_run=False,
-    ):
+        source: str,
+        args: dict[str, Any] | None = None,
+        delete: bool = True,
+        ignore_error: bool = True,
+        mask: str | None = None,
+        dry_run: bool = False,
+    ) -> None:
         if args is None:
             args = {}
         if delete:

--- a/src/bare/destination_handler.py
+++ b/src/bare/destination_handler.py
@@ -1,11 +1,19 @@
+from __future__ import annotations
+
 import os
+from types import TracebackType
 from urllib.parse import urlparse
 
 from .mount.drive import MountDrive
 
 
 class DestinationHandler:
-    def __init__(self, destination, relative_path=None, crypt=None):
+    def __init__(
+        self,
+        destination: str,
+        relative_path: str | None = None,
+        crypt: str | None = None,
+    ) -> None:
         """
         Initialize a DestinationHandler object to manage different types of storage locations.
 
@@ -21,7 +29,7 @@ class DestinationHandler:
         self.do_i_mounted = False
         self.destination_type = self.detect_destination_type()
 
-    def detect_destination_type(self):
+    def detect_destination_type(self) -> str:
         """
         Detects the type of destination based on the provided destination.
 
@@ -41,7 +49,7 @@ class DestinationHandler:
         # Otherwise, assume it's an absolute path
         return "abs_path"
 
-    def mount(self):
+    def mount(self) -> str:
         """
         Mounts the drive, checks the absolute path, or handles Restic REST server as appropriate.
 
@@ -58,7 +66,7 @@ class DestinationHandler:
         elif self.destination_type == "restic_rest_server":
             return self._handle_restic_rest_server()
 
-    def _mount_drive(self):
+    def _mount_drive(self) -> str:
         """
         Helper method to mount the drive and return the mounted path.
 
@@ -78,7 +86,7 @@ class DestinationHandler:
             mount_points[0], self.relative_path if self.relative_path else ""
         )
 
-    def _check_abs_path(self):
+    def _check_abs_path(self) -> str:
         """
         Helper method to check if the absolute path exists.
 
@@ -93,7 +101,7 @@ class DestinationHandler:
         else:
             raise FileExistsError(f"The path {self.destination} must exist.")
 
-    def _handle_restic_rest_server(self):
+    def _handle_restic_rest_server(self) -> str:
         """
         Handles the Restic REST server destination.
 
@@ -102,20 +110,25 @@ class DestinationHandler:
         """
         return self.destination
 
-    def unmount(self):
+    def unmount(self) -> None:
         """
         Unmounts the drive if it was mounted.
         """
         if self.destination_type == "volume" and self.do_i_mounted:
             self.mounter.unmount(self.destination)
 
-    def __enter__(self):
+    def __enter__(self) -> str:
         """
         Support for context manager entry. Attempts to mount the drive if necessary.
         """
         return self.mount()
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """
         Support for context manager exit. Cleans up by unmounting if necessary.
         """

--- a/src/bare/finder/__init__.py
+++ b/src/bare/finder/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/bare/finder/devices.py
+++ b/src/bare/finder/devices.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 from .gocryptfs import GocryptfsFinder
 from .physical import DriveFinder
 from .rclone import RcloneFinder
@@ -9,10 +13,10 @@ class DeviceFinder:
     Dynamically selects the appropriate method for the current operating system.
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label: str | None = None) -> None:
         self.label = label
 
-    def get_all_devices(self):
+    def get_all_devices(self) -> list[dict[str, Any]]:
         """
         Retrieves a list of all drives.
 
@@ -26,7 +30,9 @@ class DeviceFinder:
             drives.extend(s.get_drives())
         return drives
 
-    def find_device(self, label=None, name=None, path=None):
+    def find_device(
+        self, label: str | None = None, name: str | None = None, path: str | None = None
+    ) -> list[dict[str, Any]]:
         """
         Searches both physical and rclone drives for a device matching the given label or name or mountpoint (path).
 

--- a/src/bare/finder/gocryptfs.py
+++ b/src/bare/finder/gocryptfs.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import platform
+from typing import Any
 
 from ..utils import parse_mount
 
@@ -8,7 +11,7 @@ class GocryptfsFinder:
     A class dedicated to finding and formatting gocryptfs mounted drives on the system.
     """
 
-    def get_drives(self):
+    def get_drives(self) -> list[dict[str, Any]]:
         """
         Public method to get formatted gocryptfs drive details.
 
@@ -17,7 +20,7 @@ class GocryptfsFinder:
         """
         return self._format_finder(self._get_gocryptfs_mounted())
 
-    def _get_mounted_by_os(self):
+    def _get_mounted_by_os(self) -> list[dict[str, str]]:
         """
         Private method to get mount details from the operating system.
 
@@ -35,7 +38,7 @@ class GocryptfsFinder:
                 "Mount point detection not implemented for Windows."
             )
 
-    def _get_gocryptfs_mounted(self):
+    def _get_gocryptfs_mounted(self) -> list[dict[str, str]]:
         """
         Filters the mounted drives to find those specifically using 'fuse.gocryptfs'.
 
@@ -45,7 +48,7 @@ class GocryptfsFinder:
         mounts = self._get_mounted_by_os()
         return [mount for mount in mounts if mount["fstype"] == "fuse.gocryptfs"]
 
-    def _format_finder(self, drives):
+    def _format_finder(self, drives: list[dict[str, str]]) -> list[dict[str, Any]]:
         """
         Formats the list of drives into a specified structure.
 

--- a/src/bare/finder/physical.py
+++ b/src/bare/finder/physical.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import json
 import platform
 import plistlib
+from typing import Any
 
 from ..utils import execute_command
 
@@ -15,7 +18,7 @@ class DriveFinderLinux:
     DEFAULT_LABEL = ""
     DEFAULT_MOUNTPOINTS = []
 
-    def extract_partitions(self, blks):
+    def extract_partitions(self, blks: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """
         Identifies and returns all partitions (leaf nodes) from the provided block device structure.
 
@@ -29,7 +32,9 @@ class DriveFinderLinux:
         self._recurse_partitions(blks, partitions)
         return partitions
 
-    def _recurse_partitions(self, nodes, partitions):
+    def _recurse_partitions(
+        self, nodes: list[dict[str, Any]], partitions: list[dict[str, Any]]
+    ) -> None:
         """
         Recursively traverses the block device tree to find and append leaf nodes (partitions) to the partitions list.
 
@@ -43,7 +48,7 @@ class DriveFinderLinux:
             else:
                 partitions.append(node)
 
-    def get_physical_drives(self):
+    def get_physical_drives(self) -> list[dict[str, Any]]:
         """
         Retrieves and processes information about physical drives and their partitions on Linux.
 
@@ -83,7 +88,7 @@ class DriveFinderDarwin:
         "Windows_NTFS": "ntfs",
     }
 
-    def get_physical_drives(self):
+    def get_physical_drives(self) -> list[dict[str, Any]]:
         """
         Executes a command to fetch information about physical drives and their partitions,
         parsing the output into a structured list of dictionaries.
@@ -112,7 +117,7 @@ class DriveFinderDarwin:
 
         return found_devices
 
-    def _parse_disk_info(self, disk):
+    def _parse_disk_info(self, disk: dict[str, Any]) -> dict[str, Any]:
         """
         Parses disk information, applying defaults and converting filesystem types as necessary.
 
@@ -131,7 +136,7 @@ class DriveFinderDarwin:
             ),
         }
 
-    def _parse_partition_info(self, partition):
+    def _parse_partition_info(self, partition: dict[str, Any]) -> dict[str, Any]:
         """
         Parses partition information, applying defaults and converting filesystem types as necessary.
 
@@ -150,7 +155,7 @@ class DriveFinderDarwin:
             ),
         }
 
-    def _parse_mountpoint(self, data):
+    def _parse_mountpoint(self, data: dict[str, Any]) -> list[str] | str:
         """
         Parses the mount point information from the given data, adjusting paths as necessary.
 
@@ -175,7 +180,7 @@ class DriveFinderDarwin:
 
 
 class DriveFinder:
-    def get_drives(self):
+    def get_drives(self) -> list[dict[str, Any]]:
         """
         Retrieves a list of physical drives based on the operating system.
         Raises NotImplementedError for unsupported platforms.
@@ -186,7 +191,9 @@ class DriveFinder:
         finder = self._get_platform_finder()
         return finder.get_physical_drives() if finder else []
 
-    def _get_platform_finder(self):
+    def _get_platform_finder(
+        self,
+    ) -> DriveFinderLinux | DriveFinderDarwin | None:
         """
         Returns an instance of a platform-specific device finder.
 

--- a/src/bare/finder/rclone.py
+++ b/src/bare/finder/rclone.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import platform
+from typing import Any
 
 from ..utils import execute_command
 
@@ -10,7 +13,7 @@ class RcloneFinder:
     their mount points on Unix-like operating systems.
     """
 
-    def get_drives(self):
+    def get_drives(self) -> list[dict[str, Any]]:
         """
         Retrieves a list of mounted rclone drives, including their labels and filesystem type.
         Attempts to identify the mount points for each detected rclone remote.
@@ -34,7 +37,7 @@ class RcloneFinder:
         else:
             return []
 
-    def _add_mountpoint(self, mounts):
+    def _add_mountpoint(self, mounts: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """
         Adds mount point information to each rclone drive based on the operating system.
 
@@ -56,7 +59,7 @@ class RcloneFinder:
             mount["mountpoints"] = [mountpoints.get(mount["label"], [])]
         return mounts
 
-    def get_rclone_mountpoint_unix(self):
+    def get_rclone_mountpoint_unix(self) -> dict[str, str]:
         """
         Retrieves rclone mount points on Unix-like operating systems by parsing the output of
         the `ps` command to find running rclone mount processes.

--- a/src/bare/mount/__init__.py
+++ b/src/bare/mount/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/bare/mount/base.py
+++ b/src/bare/mount/base.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import os
 import stat
 import tempfile
+from typing import Any
 
 from ..finder.devices import DeviceFinder
 
@@ -11,11 +14,11 @@ class MountBase:
     managing, and cleaning up temporary directories.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.finder = DeviceFinder()
         self.prefix = "BUP.tmp."
 
-    def get_dirname(self):
+    def get_dirname(self) -> str:
         """
         Creates a temporary directory to extract its path and then removes it,
         effectively fetching a directory name for potential use.
@@ -27,7 +30,7 @@ class MountBase:
         path = os.path.dirname(temp_dir)
         return path
 
-    def generate_temporary_directory(self, symbolic=False):
+    def generate_temporary_directory(self, symbolic: bool = False) -> str:
         """
         Generates a temporary directory with restrictive permissions. If the directory
         is intended for symbolic link creation, it is removed after creation.
@@ -48,7 +51,9 @@ class MountBase:
             )  # Remove the directory if it's for symbolic link purposes.
         return temp_dir
 
-    def clean_device_temporary_directory(self, device=None, path=None):
+    def clean_device_temporary_directory(
+        self, device: dict[str, Any] | None = None, path: str | None = None
+    ) -> None:
         """
         Cleans up a temporary directory created by this instance, either specified by a device's
         mountpoint or a direct path.
@@ -69,7 +74,12 @@ class MountBase:
         if path and self.prefix in path and os.path.exists(path):
             os.rmdir(path)
 
-    def get_device(self, label=None, device_name=None, path=None):
+    def get_device(
+        self,
+        label: str | None = None,
+        device_name: str | None = None,
+        path: str | None = None,
+    ) -> dict[str, Any]:
         """
         Retrieves a device based on its label or name or mountpoint. Exactly one parameter must be provided.
 

--- a/src/bare/mount/drive.py
+++ b/src/bare/mount/drive.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .base import MountBase
 from .physical import MountDrivePhysical
 from .rclone import MountDriveRclone
@@ -9,7 +11,7 @@ class MountDrive(MountBase):
     the appropriate mounting strategy based on the drive's file system type.
     """
 
-    def mount(self, label=None, device_name=None):
+    def mount(self, label: str | None = None, device_name: str | None = None) -> bool:
         """
         Mounts a device identified by its label or name. Automatically selects
         the correct mounting strategy (rclone or physical) based on the file system type.
@@ -44,7 +46,12 @@ class MountDrive(MountBase):
     #             mount = MountDrivePhysical()
     #         mount.unmount(name=device_name, device=device, path=path)
 
-    def unmount(self, label=None, device_name=None, path=None):
+    def unmount(
+        self,
+        label: str | None = None,
+        device_name: str | None = None,
+        path: str | None = None,
+    ) -> None:
         """
         Unmounts a device identified by its label, name, or mount path. Automatically selects
         the correct unmounting strategy (rclone or physical) based on the file system type.
@@ -70,7 +77,9 @@ class MountDrive(MountBase):
 
         mounter.unmount(device=device, path=path)
 
-    def get_mountpoint(self, label=None, device_name=None):
+    def get_mountpoint(
+        self, label: str | None = None, device_name: str | None = None
+    ) -> list[str]:
         """
         Retrieves the mount points for a device identified by its label or name.
 

--- a/src/bare/mount/gocryptfs.py
+++ b/src/bare/mount/gocryptfs.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import logging
 import os
 import platform
+from typing import Any
 
 from ..bare.gocryptfs import Gocryptfs
 from ..utils import execute_command
@@ -17,13 +20,13 @@ class MountGocryptfs(MountBase):
 
     def __init__(
         self,
-        path,
-        gocryptfs_password,
-        gocryptfs_folder="",
-    ):
+        path: str,
+        gocryptfs_password: str,
+        gocryptfs_folder: str = "",
+    ) -> None:
         self.gofs = Gocryptfs(path, gocryptfs_password, gocryptfs_folder)
 
-    def mount(self, label, device=None):
+    def mount(self, label: str, device: dict[str, Any] | None = None) -> bool:
         """
         Mounts a gocryptfs-encrypted directory if it is not already mounted.
 
@@ -64,7 +67,12 @@ class MountGocryptfs(MountBase):
             )
             return False
 
-    def unmount(self, label=None, device=None, path=None):
+    def unmount(
+        self,
+        label: str | None = None,
+        device: dict[str, Any] | None = None,
+        path: str | None = None,
+    ) -> None:
         """
         Unmounts a remote filesystem identified by a label, device dictionary, or mount path.
 

--- a/src/bare/mount/physical.py
+++ b/src/bare/mount/physical.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import logging
 import platform
+from typing import Any
 
 from ..utils import execute_command
 from .base import MountBase
@@ -13,7 +16,7 @@ class MountDriveLinux(MountBase):
     Leverages `udisksctl` for performing the mount and unmount operations.
     """
 
-    def mount(self, device_name):
+    def mount(self, device_name: str) -> None:
         """
         Mounts a device by its name using `udisksctl`.
 
@@ -29,7 +32,7 @@ class MountDriveLinux(MountBase):
         except Exception as e:
             raise RuntimeError(f"Failed to mount /dev/{device_name}: {e}") from e
 
-    def unmount(self, path):
+    def unmount(self, path: str) -> None:
         """
         Unmounts a device by its mount path using `udisksctl`.
 
@@ -62,7 +65,7 @@ class MountDriveDarwin(MountBase):
     Uses the `diskutil` command-line utility for mounting operations.
     """
 
-    def mount(self, device_name):
+    def mount(self, device_name: str) -> None:
         """
         Mounts a device by its name to a temporary directory created for this purpose.
 
@@ -79,7 +82,7 @@ class MountDriveDarwin(MountBase):
         except Exception as e:
             raise RuntimeError(f"Failed to mount /dev/{device_name}: {e}") from e
 
-    def unmount(self, path):
+    def unmount(self, path: str) -> None:
         """
         Unmounts a device from a specified path.
 
@@ -98,14 +101,14 @@ class MountDriveDarwin(MountBase):
 
 class MountDriveWin(MountBase):
     # TODO:
-    def mount(self, device_name):
+    def mount(self, device_name: str) -> None:
         self.generate_temporary_directory()
         # Create a diskpart script to assign a drive letter
         # script = f"select volume {volume}\nassign letter={drive_letter}"
         # process = subprocess.run(['diskpart'], input=script.encode(), check=True)
         # execute_command(cmd)
 
-    def unmount(self, device_name):
+    def unmount(self, device_name: str) -> None:
         self.generate_temporary_directory()
         # Create a diskpart script to assign a drive letter
         # script = f"select volume {volume}\nassign letter={drive_letter}"
@@ -120,7 +123,9 @@ class MountDrivePhysical(MountBase):
     on the runtime OS.
     """
 
-    def mount(self, name=None, device=None):
+    def mount(
+        self, name: str | None = None, device: dict[str, Any] | None = None
+    ) -> bool:
         """
         Mounts a physical drive identified by its name or device dictionary. Automatically
         selects the correct mounting mechanism based on the operating system.
@@ -146,7 +151,12 @@ class MountDrivePhysical(MountBase):
             logger.info(f"Device is already mounted at: {device['mountpoints']}")
             return False
 
-    def unmount(self, name=None, device=None, path=None):
+    def unmount(
+        self,
+        name: str | None = None,
+        device: dict[str, Any] | None = None,
+        path: str | None = None,
+    ) -> None:
         """
         Unmounts a physical drive identified by its name, device dictionary, or path. Automatically
         selects the correct unmounting mechanism based on the operating system.
@@ -176,7 +186,7 @@ class MountDrivePhysical(MountBase):
         else:
             logger.info("Device is already unmounted or no mount point found.")
 
-    def _get_mounter(self):
+    def _get_mounter(self) -> MountBase:
         """
         Determines the appropriate mounter subclass based on the current operating system.
 

--- a/src/bare/mount/rclone.py
+++ b/src/bare/mount/rclone.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import logging
 import os
 import platform
+from typing import Any
 
 from ..utils import execute_command
 from .base import MountBase
@@ -14,7 +17,9 @@ class MountDriveRclone(MountBase):
     Supports operations on Linux and Darwin operating systems.
     """
 
-    def mount(self, label=None, device=None):
+    def mount(
+        self, label: str | None = None, device: dict[str, Any] | None = None
+    ) -> bool:
         """
         Mounts a remote filesystem identified by a label or device dictionary to a temporary directory.
 
@@ -43,7 +48,12 @@ class MountDriveRclone(MountBase):
             logger.info(f"Device is already mounted at: {device['mountpoints']}")
             return False
 
-    def unmount(self, label=None, device=None, path=None):
+    def unmount(
+        self,
+        label: str | None = None,
+        device: dict[str, Any] | None = None,
+        path: str | None = None,
+    ) -> None:
         """
         Unmounts a remote filesystem identified by a label, device dictionary, or mount path.
 

--- a/src/bare/mount_manager.py
+++ b/src/bare/mount_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 
@@ -8,7 +10,7 @@ from .utils import execute_command
 
 
 class MountPointFinder:
-    def find_device(self, mount_point):
+    def find_device(self, mount_point: str) -> str | None:
         """Determine the method to use based on the operating system."""
         os_type = platform.system()
         if os_type == "Linux" or os_type == "Unix":
@@ -20,7 +22,7 @@ class MountPointFinder:
         else:
             raise NotImplementedError(f"OS {os_type} not supported.")
 
-    def _find_device_unix(self, mount_point):
+    def _find_device_unix(self, mount_point: str) -> str | None:
         """Find the device mounted at `mount_point` for Unix/Linux."""
         with open("/proc/mounts") as mounts:
             for line in mounts:
@@ -30,7 +32,7 @@ class MountPointFinder:
                     return parts[0].split("/dev/")[1]
         return None
 
-    def _find_device_darwin(self, mount_point):
+    def _find_device_darwin(self, mount_point: str) -> str | None:
         """Find the device mounted at `mount_point` on macOS."""
         # TODO
         out = execute_command("mount")
@@ -42,7 +44,7 @@ class MountPointFinder:
                 return parts[0].split("/dev/")[1]
         return None
 
-    def _find_device_windows(self, mount_point):
+    def _find_device_windows(self, mount_point: str) -> str | None:
         """Find the volume of the drive with the given letter on Windows."""
         # Adjust `mount_point` to match the expected input format for Windows (e.g., "C:")
         if not mount_point.endswith(":"):
@@ -71,7 +73,7 @@ class MountManager:
         self.mounter = MountDrive()
         self.mount_finder = MountPointFinder()
 
-    def get_mounted_devices(self):
+    def get_mounted_devices(self) -> dict[str, str]:
         """
         Retrieves a dictionary of currently mounted devices and their mount points.
 
@@ -82,16 +84,17 @@ class MountManager:
         ls = os.listdir(dirname)
         my_files = [x for x in ls if self.mount_base.prefix in x]
 
-        devices = {}
+        devices: dict[str, str] = {}
         for file in my_files:
             path = os.path.join(dirname, file)
             if os.path.ismount(path):
                 device = self.mount_finder.find_device(path)
-                devices[device] = path
+                if device is not None:
+                    devices[device] = path
 
         return devices
 
-    def umount_all(self):
+    def umount_all(self) -> None:
         """
         Unmounts all mounted devices that were mounted through this manager.
         Raises an exception if a device cannot be found.
@@ -102,7 +105,7 @@ class MountManager:
         for _, path in mounted_devices.items():
             self.mounter.unmount(path=path)
 
-    def clean(self):
+    def clean(self) -> None:
         """
         Cleans up all temporary directories and broken symbolic links created by the mount operations.
         """
@@ -116,7 +119,7 @@ class MountManager:
             elif not os.path.ismount(path) and not os.listdir(path):
                 os.rmdir(path)
 
-    def get_folders_created(self):
+    def get_folders_created(self) -> list[str]:
         """
         Retrieves a list of folder names created by the mount operations.
 
@@ -127,7 +130,7 @@ class MountManager:
         ls = os.listdir(dirname)
         return [x for x in ls if self.mount_base.prefix in x]
 
-    def clean_broken_symbolic_link(self, path):
+    def clean_broken_symbolic_link(self, path: str) -> None:
         """
         Cleans up a broken symbolic link.
 

--- a/src/bare/scripts/schedule_runner.py
+++ b/src/bare/scripts/schedule_runner.py
@@ -4,6 +4,8 @@ Backup launcher for bare backup (custom CLI) inside micromamba environment.
 Handles daily execution, logging, Tailscale startup, and connectivity checks.
 """
 
+from __future__ import annotations
+
 import datetime as dt
 import logging
 import os

--- a/tests/test_destination_handler.py
+++ b/tests/test_destination_handler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 
@@ -8,17 +10,17 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from bare.destination_handler import DestinationHandler
 
 
-def test_detect_destination_type_restic():
+def test_detect_destination_type_restic() -> None:
     dh = DestinationHandler("rest:https://example.com")
     assert dh.destination_type == "restic_rest_server"
 
 
-def test_detect_destination_type_volume():
+def test_detect_destination_type_volume() -> None:
     dh = DestinationHandler("myvolume")
     assert dh.destination_type == "volume"
 
 
-def test_check_abs_path(tmp_path: Path):
+def test_check_abs_path(tmp_path: Path) -> None:
     path = tmp_path / "data"
     path.mkdir()
     dh = DestinationHandler(str(path))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,17 +1,21 @@
+from __future__ import annotations
+
 import platform
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from bare.utils import build_command, dict2args, modify_command_for_os
 
 
-def test_build_command():
+def test_build_command() -> None:
     assert build_command("echo", "hi", 1) == "echo hi 1"
 
 
-def test_dict2args():
+def test_dict2args() -> None:
     args = {"exclude": "/tmp", "I": ["a", "b"]}
     result = dict2args(args)
     assert "--exclude /tmp" in result
@@ -19,7 +23,9 @@ def test_dict2args():
     assert "-I b" in result
 
 
-def test_modify_command_for_os_linux_with_mask(monkeypatch):
+def test_modify_command_for_os_linux_with_mask(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(platform, "system", lambda: "Linux")
     cmd = modify_command_for_os("ls", ["src", "dst"])
     assert cmd == "proot -b src:dst ls"


### PR DESCRIPTION
## Summary
- add `from __future__ import annotations` and type annotations across source and test modules
- type devices, mount handlers, backup helpers, and scripts for better static checks

## Testing
- `pre-commit run --files src/bare/__init__.py src/bare/bare/__init__.py src/bare/bare/backup.py src/bare/bare/base.py src/bare/bare/gocryptfs.py src/bare/bare/restic.py src/bare/bare/rsync.py src/bare/destination_handler.py src/bare/finder/__init__.py src/bare/finder/devices.py src/bare/finder/gocryptfs.py src/bare/finder/physical.py src/bare/finder/rclone.py src/bare/mount/__init__.py src/bare/mount/base.py src/bare/mount/drive.py src/bare/mount/gocryptfs.py src/bare/mount/physical.py src/bare/mount/rclone.py src/bare/scripts/schedule_runner.py tests/test_destination_handler.py tests/test_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa0e6ae8a88324b16dceb43408cbb5